### PR TITLE
Pin sh to >=2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
 license = {file = "LICENSE"}
 dependencies = [
     'requests',
-    'sh',
+    'sh>=2.0.0',
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
`sh` made a change in [2.0.0](https://github.com/amoffat/sh/blob/develop/CHANGELOG.md#200---2922)
> Executed commands now return a unicode string by default

This ensures that the results of commands like `sh.pip("list", ...)` return a string that can then be deserialized. I ran into an issue when testing this library with another repository that had an older version of `sh` installed.