### PR TITLE
Fix yarn issues

### DIFF
--- a/dependency_metrics/constants.py
+++ b/dependency_metrics/constants.py
@@ -5,6 +5,8 @@ REPO = "REPO"
 PIP = 'pip'
 YARN = 'yarn'
 
+UNKNOWN_VERSION = "unknown"
+
 
 class MetricType:
     GAUGE = 'gauge'

--- a/dependency_metrics/package_managers/yarn.py
+++ b/dependency_metrics/package_managers/yarn.py
@@ -3,6 +3,7 @@ from json import JSONDecodeError
 
 import sh
 
+from dependency_metrics.constants import UNKNOWN_VERSION
 from dependency_metrics.exceptions import Crash
 
 
@@ -16,7 +17,7 @@ def get_yarn_packages():
         latest_version = pull_latest_version(package["name"])
         if package["version"] != latest_version:
             # only care if it is actually outdated
-            package["latest_version"] = latest_version if latest_version else "unknown"
+            package["latest_version"] = latest_version
             outdated_packages.append(package)
     return outdated_packages
 
@@ -25,21 +26,21 @@ def pull_latest_version(package_name):
     """
     Attempts to pull latest version of package from yarn
     :param package_name: name of javascript package
-    :returns: returns version as string, or None if not found
+    :returns: returns version as string, or UNKNOWN_VERSION if not found
     """
     string_output = Yarn.latest_version(package_name)
     if not string_output:
-        return None
+        return UNKNOWN_VERSION
 
     try:
         json_output = json.loads(string_output)
     except JSONDecodeError:
-        return None
+        return UNKNOWN_VERSION
 
     if json_output.get('type') == 'inspect':
         return json_output.get('data')
 
-    return None
+    return UNKNOWN_VERSION
 
 
 def parse_yarn_list():

--- a/dependency_metrics/package_managers/yarn.py
+++ b/dependency_metrics/package_managers/yarn.py
@@ -6,6 +6,30 @@ import sh
 from dependency_metrics.constants import UNKNOWN_VERSION
 from dependency_metrics.exceptions import Crash
 
+"""
+Yarn doesn't have any explicitly stated naming conventions for packages.
+See here: https://yarnpkg.com/configuration/manifest. It is unclear if 
+package names are case-sensitive or not.
+
+When using ``yarn info`` for a specific package, yarn expects the name defined
+in package.json to be used, which is not necessarily the same as the name 
+fetched via ``yarn list``.
+
+Example:
+``yarn list --depth 0 | grep At.js`` => At.js@1.5.3
+``yarn info At.js dist-tags.latest --json`` => {"type": "error", "data": "Received invalid response from npm."}
+``yarn info at.js dist-tags.latest --json`` => {"type":"inspect","data":"1.5.4"}
+
+The current behavior is to only use the name obtained from ``yarn list``. If 
+that results in an error, the code below sets ``latest_version`` to "unknown". 
+This has been the behavior up until now, so this will continue to be the 
+behavior.
+
+If new information is found that clearly states yarn package names are 
+case-insensitive, then the behavior can change to retry package names that fail 
+with a lower cased version of the name.
+"""
+
 
 def get_yarn_packages():
     version = Yarn.version()

--- a/tests/package_managers/test_yarn.py
+++ b/tests/package_managers/test_yarn.py
@@ -2,6 +2,7 @@ from textwrap import dedent
 from unittest import TestCase, mock
 from unittest.mock import patch
 
+from dependency_metrics.constants import UNKNOWN_VERSION
 from dependency_metrics.exceptions import Crash
 from dependency_metrics.package_managers.yarn import (
     get_yarn_packages,
@@ -32,7 +33,7 @@ class GetYarnPackagesTests(TestCase):
     @patch('dependency_metrics.package_managers.yarn.parse_yarn_list')
     @patch('dependency_metrics.package_managers.yarn.pull_latest_version')
     def test_unknown_latest_version(self, mock_latest_version, mock_yarn_list):
-        mock_latest_version.return_value = None
+        mock_latest_version.return_value = UNKNOWN_VERSION
         mock_yarn_list.return_value = [{"name": "test", "version": "1.0.0"}]
 
         packages = get_yarn_packages()
@@ -77,17 +78,17 @@ class PullLatestVersionTests(TestCase):
         latest_version = pull_latest_version(mock.ANY)
         self.assertEqual(latest_version, "5.0.0")
 
-    def test_returns_none_if_latest_version_is_empty(self, mock_latest_version):
+    def test_returns_unknown_if_latest_version_is_empty(self, mock_latest_version):
         mock_latest_version.return_value = None
         latest_version = pull_latest_version(mock.ANY)
-        self.assertIsNone(latest_version)
+        self.assertEqual(latest_version, UNKNOWN_VERSION)
 
-    def test_returns_none_if_error(self, mock_latest_version):
+    def test_returns_unknown_if_error(self, mock_latest_version):
         mock_latest_version.return_value = '{"type": "error", "data": "Received invalid response from npm."}\n'
         latest_version = pull_latest_version(mock.ANY)
-        self.assertIsNone(latest_version)
+        self.assertEqual(latest_version, UNKNOWN_VERSION)
 
-    def test_returns_none_if_json_load_fails(self, mock_latest_version):
+    def test_returns_unknown_if_json_load_fails(self, mock_latest_version):
         mock_latest_version.return_value = ''
         latest_version = pull_latest_version(mock.ANY)
-        self.assertIsNone(latest_version)
+        self.assertEqual(latest_version, UNKNOWN_VERSION)

--- a/tests/package_managers/test_yarn.py
+++ b/tests/package_managers/test_yarn.py
@@ -73,9 +73,7 @@ class ParseYarnListTests(TestCase):
 class PullLatestVersionTests(TestCase):
 
     def test_returns_latest_version_successfully(self, mock_latest_version):
-        mock_latest_version.return_value = dedent("""yarn info v1.22.19
-        5.0.0
-        Done in 0.16s.""")
+        mock_latest_version.return_value = '{"type":"inspect","data":"5.0.0"}\n'
         latest_version = pull_latest_version(mock.ANY)
         self.assertEqual(latest_version, "5.0.0")
 
@@ -84,7 +82,12 @@ class PullLatestVersionTests(TestCase):
         latest_version = pull_latest_version(mock.ANY)
         self.assertIsNone(latest_version)
 
-    def test_raises_assertion_error_if_output_line_count_mismatch(self, mock_latest_version):
-        mock_latest_version.return_value = "5.0.0"
-        with self.assertRaises(AssertionError):
-            pull_latest_version(mock.ANY)
+    def test_returns_none_if_error(self, mock_latest_version):
+        mock_latest_version.return_value = '{"type": "error", "data": "Received invalid response from npm."}\n'
+        latest_version = pull_latest_version(mock.ANY)
+        self.assertIsNone(latest_version)
+
+    def test_returns_none_if_json_load_fails(self, mock_latest_version):
+        mock_latest_version.return_value = ''
+        latest_version = pull_latest_version(mock.ANY)
+        self.assertIsNone(latest_version)


### PR DESCRIPTION
#### ce830f1ab3a0ff516ea57f1bc344335ef248ee69 (first commit)

When testing `metrics yarn` in commcare-hq, I hit an `AssertionError` with the stack trace: 
```
...
    latest_version = pull_latest_version(package["name"])
  File "/Users/grahamherceg/.pyenv/versions/3.9.16/envs/hq-3.9.16/lib/python3.9/site-packages/dependency_metrics/package_managers/yarn.py", line 27, in pull_latest_version
    assert len(lines) == 1, f"{package_name}: invalid latest: {lines!r}"
AssertionError: At.js: invalid latest: []
```

Previously, this worked because the check for an empty value occurred after calling `.splitlines[1:-1]` on the returned output from `yarn info ...`. I accidentally changed behavior to where the check for an empty output happened before splitting lines, which means we did not return from the method when we should have.

However upon further investigation, the output from `sh.yarn("info", ...)` contained many escape characters, which made it annoying to parse. The updated solution is to pass the `--json` option into `sh.yarn("info", ...)` which returns a much easier to work with output.

#### ee97a31c5d753938450d4988eba93534c4fb4e44 (second commit)

Simple refactor to simplify `get_yarn_packages`. 

#### c5b24a013326fd229c4a1029905bbf779cb60cc1 (third commit)
Additionally, there was some strange behavior with `At.js`, but to keep this consistent with how it has been functioning behavior was not modified to account for the error fetching latest version info for `At.js`. See the commit for a more detailed explanation.