### PR TITLE
requests.post expects json, not string

### DIFF
--- a/dependency_metrics/datadog_utils.py
+++ b/dependency_metrics/datadog_utils.py
@@ -1,4 +1,3 @@
-import json
 import os
 import time
 
@@ -64,7 +63,7 @@ def send_metric(name, value, metric_type, tags=None):
             'tags': [f'{key}:{value}' for key, value in tags.items()]
         }]
     }
-    requests.post(url, headers=headers, json=json.dumps(payload))
+    requests.post(url, headers=headers, json=payload)
 
 
 def get_metric_name_for_package_manager(key):

--- a/dependency_metrics/datadog_utils.py
+++ b/dependency_metrics/datadog_utils.py
@@ -63,7 +63,13 @@ def send_metric(name, value, metric_type, tags=None):
             'tags': [f'{key}:{value}' for key, value in tags.items()]
         }]
     }
-    requests.post(url, headers=headers, json=payload)
+    response = requests.post(url, headers=headers, json=payload)
+    if not response.ok:
+        print(
+            f"Post request to {url} failed with status code "
+            f"{response.status_code} and error {response.text}\n"
+            f"The payload sent was {payload}"
+        )
 
 
 def get_metric_name_for_package_manager(key):

--- a/tests/test_datadog_utils.py
+++ b/tests/test_datadog_utils.py
@@ -47,7 +47,7 @@ class SendMetricTests(TestCase):
         send_metric('name', 'value', MetricType.GAUGE)
 
         args, kwargs = mock_post.call_args
-        payload = json.loads(kwargs['json'])
+        payload = kwargs['json']
         self.assertEqual(payload['series'][0]['metric'], 'name')
         self.assertEqual(payload['series'][0]['points'], [[1577874030, 'value']])
         self.assertEqual(payload['series'][0]['host'], 'unknown')
@@ -59,7 +59,7 @@ class SendMetricTests(TestCase):
         send_metric('name', 'value', MetricType.GAUGE)
 
         args, kwargs = mock_post.call_args
-        payload = json.loads(kwargs['json'])
+        payload = kwargs['json']
         self.assertEqual(payload['series'][0]['host'], 'test-repo')
 
     def test_metric_type_is_gauge_when_set(self, mock_post):
@@ -68,7 +68,7 @@ class SendMetricTests(TestCase):
         send_metric('name', 'value', MetricType.GAUGE)
 
         args, kwargs = mock_post.call_args
-        payload = json.loads(kwargs['json'])
+        payload = kwargs['json']
         self.assertEqual(payload['series'][0]['type'], MetricType.GAUGE)
 
     def test_metric_type_is_count_when_set(self, mock_post):
@@ -77,7 +77,7 @@ class SendMetricTests(TestCase):
         send_metric('name', 'value', MetricType.COUNT)
 
         args, kwargs = mock_post.call_args
-        payload = json.loads(kwargs['json'])
+        payload = kwargs['json']
         self.assertEqual(payload['series'][0]['type'], MetricType.COUNT)
 
     def test_metric_type_is_rate_when_set(self, mock_post):
@@ -86,7 +86,7 @@ class SendMetricTests(TestCase):
         send_metric('name', 'value', MetricType.RATE)
 
         args, kwargs = mock_post.call_args
-        payload = json.loads(kwargs['json'])
+        payload = kwargs['json']
         self.assertEqual(payload['series'][0]['type'], MetricType.RATE)
 
     def _setup_env(self, **kwargs):


### PR DESCRIPTION
straightforward. requests.post was already handling calling `json.dumps` on the payload, so by calling it prior to passing into the post method, it was getting doubly escaped which made datadog unable to read the payload.