### PR TITLE
Include total count of dependencies in stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Use the `--stats` option to generate a simple dictionary that displays the total
 
 ```commandline
 $ metrics pip --stats
+Total: 5
 Outdated: 2
 Multi-Major: 1
 Major: 0

--- a/dependency_metrics/datadog_utils.py
+++ b/dependency_metrics/datadog_utils.py
@@ -82,6 +82,7 @@ def get_metric_name_for_package_manager(key):
 
 def get_metric_name_for_stats_key(key):
     metric_name_map = {
+        "Total": "total",
         "Outdated": "outdated",
         "Multi-Major": "multi_major_outdated",
         "Major": "major_outdated",

--- a/dependency_metrics/metrics.py
+++ b/dependency_metrics/metrics.py
@@ -2,7 +2,7 @@ import argparse
 
 from dependency_metrics.constants import PIP, YARN
 from dependency_metrics.datadog_utils import send_stats_to_datadog
-from dependency_metrics.package_managers.utils import iter_packages
+from dependency_metrics.package_managers.utils import iter_outdated_packages
 
 
 def build_packages_table(packages):
@@ -31,7 +31,7 @@ def build_packages_table(packages):
     return rows
 
 
-def get_package_stats(packages):
+def get_outdated_package_stats(packages):
     """Displays a count for each version category of out of date dependencies"""
     stats = {
         "Outdated": 0,
@@ -87,9 +87,9 @@ def main():
     )
     args = parser.parse_args()
 
-    packages = iter_packages(args.package_manager)
+    outdated_packages = iter_outdated_packages(args.package_manager)
     if args.stats or args.send:
-        stats = get_package_stats(packages)
+        stats = get_outdated_package_stats(outdated_packages)
         if args.stats:
             # NOTE: subtle detail: we're depending on Python 3's ordered dict to
             # maintain deterministic ordering here
@@ -99,7 +99,7 @@ def main():
             send_stats_to_datadog(stats, args.package_manager)
 
     else:
-        package_table = build_packages_table(packages)
+        package_table = build_packages_table(outdated_packages)
         for row in package_table:
             print(row)
 

--- a/dependency_metrics/package_managers/pip.py
+++ b/dependency_metrics/package_managers/pip.py
@@ -7,7 +7,7 @@ def get_pip_packages():
     """
     Return relevant package version info from pip list output
     """
-    pip_packages = json.loads(Pip.list())
+    pip_packages = json.loads(Pip.list(outdated=True))
     cleaned_package_info_list = []
     for pkg_info in pip_packages:
         del pkg_info['latest_filetype']
@@ -15,11 +15,22 @@ def get_pip_packages():
     return cleaned_package_info_list
 
 
+def get_total_count_for_pip():
+    """
+    Return total number of installed dependencies
+    """
+    packages = json.loads(Pip.list())
+    return len(packages)
+
+
 class Pip:
 
     @staticmethod
-    def list():
+    def list(outdated=False):
         """
-        Equivalent to ``pip list --format json --outdated``
+        Equivalent to ``pip list --format json [--outdated]``
         """
-        return sh.pip("list", "--format", "json", "--outdated")
+        args = ["list", "--format", "json"]
+        if outdated:
+            args.append("--outdated")
+        return sh.pip(*args)

--- a/dependency_metrics/package_managers/pip.py
+++ b/dependency_metrics/package_managers/pip.py
@@ -3,7 +3,7 @@ import json
 import sh
 
 
-def get_pip_packages():
+def get_outdated_pip_packages():
     """
     Return relevant package version info from pip list output
     """

--- a/dependency_metrics/package_managers/utils.py
+++ b/dependency_metrics/package_managers/utils.py
@@ -1,29 +1,44 @@
 from dependency_metrics.constants import PIP, YARN
-from dependency_metrics.package_managers.pip import get_pip_packages
-from dependency_metrics.package_managers.yarn import get_yarn_packages
+from dependency_metrics.package_managers.pip import (get_outdated_pip_packages,
+                                                     get_total_count_for_pip)
+from dependency_metrics.package_managers.yarn import (get_total_count_for_yarn,
+                                                      get_outdated_yarn_packages)
 from dependency_metrics.parsing_utils import behind
 
 
-def iter_packages(package_manager):
+def iter_outdated_packages(package_manager):
     """
     Obtains packages given a manager, and builds package info tuple
     :param package_manager: str representing package manager
     :return: generator of package info (behind, name, latest, current)
     """
-    for package_info in get_packages(package_manager):
+    for package_info in get_outdated_packages(package_manager):
         latest = package_info["latest_version"]
         current = package_info["version"]
         yield behind(latest, current), package_info["name"], latest, current
 
 
-def get_packages(package_manager):
+def get_outdated_packages(package_manager):
     """
     :param package_manager: str representing package manager
     :return: function to retrieve packages for the provided package manager
     """
     package_list_map = {
-        PIP: get_pip_packages,
-        YARN: get_yarn_packages,
+        PIP: get_outdated_pip_packages,
+        YARN: get_outdated_yarn_packages,
     }
 
     return package_list_map[package_manager]()
+
+
+def get_total_package_count(package_manager):
+    """
+    :param package_manager: str representing package manager
+    :return: count of total number of packages installed via package manager
+    """
+    package_count_map = {
+        PIP: get_total_count_for_pip,
+        YARN: get_total_count_for_yarn,
+    }
+
+    return package_count_map[package_manager]()

--- a/dependency_metrics/package_managers/yarn.py
+++ b/dependency_metrics/package_managers/yarn.py
@@ -31,7 +31,7 @@ with a lower cased version of the name.
 """
 
 
-def get_yarn_packages():
+def get_outdated_yarn_packages():
     version = Yarn.version()
     if not version.startswith("1."):
         raise Crash(f"Yarn Classic (v1.x) is required, found {version}")

--- a/dependency_metrics/package_managers/yarn.py
+++ b/dependency_metrics/package_managers/yarn.py
@@ -46,6 +46,13 @@ def get_yarn_packages():
     return outdated_packages
 
 
+def get_total_count_for_yarn():
+    """
+    Return total number of installed dependencies
+    """
+    return len(parse_yarn_list())
+
+
 def pull_latest_version(package_name):
     """
     Attempts to pull latest version of package from yarn

--- a/tests/package_managers/test_pip.py
+++ b/tests/package_managers/test_pip.py
@@ -1,6 +1,7 @@
 from unittest import TestCase, mock
 
-from dependency_metrics.package_managers.pip import get_pip_packages
+from dependency_metrics.package_managers.pip import (get_pip_packages,
+                                                     get_total_count_for_pip)
 
 
 @mock.patch('dependency_metrics.package_managers.pip.Pip')
@@ -14,3 +15,15 @@ class GetPipPackagesTests(TestCase):
         result = get_pip_packages()
         self.assertEqual(result, [
             {"name": "test", "version": "1.0", "latest_version": "5.0"}])
+
+
+@mock.patch('dependency_metrics.package_managers.pip.Pip')
+class GetTotalCountForPipTests(TestCase):
+
+    def test_returns_accurate_count(self, mock_pip):
+        mock_pip.list.return_value = '[{"name": "test", "version": "1.0", ' \
+                                     '"latest_filetype": "wheel"}, {"name": ' \
+                                     '"test2", "version": "5.1", ' \
+                                     '"latest_filetype": "wheel"}]'
+        result = get_total_count_for_pip()
+        self.assertEqual(result, 2)

--- a/tests/package_managers/test_pip.py
+++ b/tests/package_managers/test_pip.py
@@ -1,18 +1,18 @@
 from unittest import TestCase, mock
 
-from dependency_metrics.package_managers.pip import (get_pip_packages,
+from dependency_metrics.package_managers.pip import (get_outdated_pip_packages,
                                                      get_total_count_for_pip)
 
 
 @mock.patch('dependency_metrics.package_managers.pip.Pip')
-class GetPipPackagesTests(TestCase):
+class GetOutdatedPipPackagesTests(TestCase):
 
     def test_returned_format_is_correct(self, mock_pip):
         # simulating what is returned by `pip list --format json --outdated`
         mock_pip.list.return_value = '[{"name": "test", "version": "1.0", ' \
                                      '"latest_version": "5.0", ' \
                                      '"latest_filetype": "wheel"}]'
-        result = get_pip_packages()
+        result = get_outdated_pip_packages()
         self.assertEqual(result, [
             {"name": "test", "version": "1.0", "latest_version": "5.0"}])
 

--- a/tests/package_managers/test_utils.py
+++ b/tests/package_managers/test_utils.py
@@ -1,31 +1,31 @@
 from unittest import TestCase, mock
 
-from dependency_metrics.package_managers.utils import iter_packages
+from dependency_metrics.package_managers.utils import iter_outdated_packages
 
 
-@mock.patch('dependency_metrics.package_managers.utils.get_packages')
-class IterPackagesTests(TestCase):
+@mock.patch('dependency_metrics.package_managers.utils.get_outdated_packages')
+class IterOutdatedPackagesTests(TestCase):
 
-    def test_major_version_out_of_date(self, mock_packages):
-        mock_packages.return_value = [
+    def test_major_version_out_of_date(self, mock_outdated_packages):
+        mock_outdated_packages.return_value = [
             {"name": "test", "version": "1.0", "latest_version": "5.0"}]
-        result = list(iter_packages(mock.ANY))
+        result = list(iter_outdated_packages(mock.ANY))
         self.assertEqual(result, [([4, 0, 0], 'test', '5.0', '1.0')])
 
-    def test_minor_version_out_of_date(self, mock_packages):
-        mock_packages.return_value = [
+    def test_minor_version_out_of_date(self, mock_outdated_packages):
+        mock_outdated_packages.return_value = [
             {"name": "test", "version": "1.0", "latest_version": "1.7"}]
-        result = list(iter_packages(mock.ANY))
+        result = list(iter_outdated_packages(mock.ANY))
         self.assertEqual(result, [([0, 7, 0], 'test', '1.7', '1.0')])
 
-    def test_patch_version_out_of_date(self, mock_packages):
-        mock_packages.return_value = [
+    def test_patch_version_out_of_date(self, mock_outdated_packages):
+        mock_outdated_packages.return_value = [
             {"name": "test", "version": "1.0.0", "latest_version": "1.0.10"}]
-        result = list(iter_packages(mock.ANY))
+        result = list(iter_outdated_packages(mock.ANY))
         self.assertEqual(result, [([0, 0, 10], 'test', '1.0.10', '1.0.0')])
 
-    def test_unknown_version(self, mock_packages):
-        mock_packages.return_value = [
+    def test_unknown_version(self, mock_outdated_packages):
+        mock_outdated_packages.return_value = [
             {"name": "test", "version": "1.0.0", "latest_version": "unknown"}]
-        result = list(iter_packages(mock.ANY))
+        result = list(iter_outdated_packages(mock.ANY))
         self.assertEqual(result, [(None, 'test', 'unknown', '1.0.0')])

--- a/tests/package_managers/test_yarn.py
+++ b/tests/package_managers/test_yarn.py
@@ -6,8 +6,9 @@ from dependency_metrics.constants import UNKNOWN_VERSION
 from dependency_metrics.exceptions import Crash
 from dependency_metrics.package_managers.yarn import (
     get_yarn_packages,
+    get_total_count_for_yarn,
     parse_yarn_list,
-    pull_latest_version
+    pull_latest_version,
 )
 
 
@@ -92,3 +93,14 @@ class PullLatestVersionTests(TestCase):
         mock_latest_version.return_value = ''
         latest_version = pull_latest_version(mock.ANY)
         self.assertEqual(latest_version, UNKNOWN_VERSION)
+
+
+@patch('dependency_metrics.package_managers.yarn.parse_yarn_list')
+class GetTotalCountForYarnTests(TestCase):
+
+    def test_returns_accurate_count(self, mock_yarn_list):
+        mock_yarn_list.return_value = [
+            {"name": "test", "version": "1.0.0"},
+            {"name": "test2", "version": "5.1"}]
+        result = get_total_count_for_yarn()
+        self.assertEqual(result, 2)

--- a/tests/package_managers/test_yarn.py
+++ b/tests/package_managers/test_yarn.py
@@ -5,20 +5,20 @@ from unittest.mock import patch
 from dependency_metrics.constants import UNKNOWN_VERSION
 from dependency_metrics.exceptions import Crash
 from dependency_metrics.package_managers.yarn import (
-    get_yarn_packages,
+    get_outdated_yarn_packages,
     get_total_count_for_yarn,
     parse_yarn_list,
     pull_latest_version,
 )
 
 
-class GetYarnPackagesTests(TestCase):
+class GetOutdatedYarnPackagesTests(TestCase):
 
     @patch('dependency_metrics.package_managers.yarn.Yarn')
     def test_exception_raised_if_wrong_yarn_version(self, mock_yarn):
         mock_yarn.version.return_value = "2.0"
         with self.assertRaises(Crash):
-            get_yarn_packages()
+            get_outdated_yarn_packages()
 
     @patch('dependency_metrics.package_managers.yarn.parse_yarn_list')
     @patch('dependency_metrics.package_managers.yarn.pull_latest_version')
@@ -26,7 +26,7 @@ class GetYarnPackagesTests(TestCase):
         mock_latest_version.return_value = "5.0.0"
         mock_yarn_list.return_value = [{"name": "test", "version": "1.0.0"}]
 
-        packages = get_yarn_packages()
+        packages = get_outdated_yarn_packages()
 
         self.assertEqual(packages, [
             {"name": "test", "version": "1.0.0", "latest_version": "5.0.0"}])
@@ -37,7 +37,7 @@ class GetYarnPackagesTests(TestCase):
         mock_latest_version.return_value = UNKNOWN_VERSION
         mock_yarn_list.return_value = [{"name": "test", "version": "1.0.0"}]
 
-        packages = get_yarn_packages()
+        packages = get_outdated_yarn_packages()
 
         self.assertEqual(packages, [
             {"name": "test", "version": "1.0.0", "latest_version": "unknown"}])

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
-from dependency_metrics.metrics import build_packages_table, get_package_stats
+from dependency_metrics.metrics import (build_packages_table,
+                                        get_outdated_package_stats)
 
 
 class BuildPackagesTableTests(TestCase):
@@ -21,11 +22,11 @@ class BuildPackagesTableTests(TestCase):
         self.assertEqual(rows[1], "0.0.0    test                         1.0          1.0")
 
 
-class GetPackageStatsTests(TestCase):
+class GetOutdatedPackageStatsTests(TestCase):
 
     def test_outdated_multi_major_package(self):
         packages = [([2, 0, 0], 'test', '3.1', '1.0')]
-        stats = get_package_stats(packages)
+        stats = get_outdated_package_stats(packages)
         self.assertEqual(stats, {
             "Outdated": 1,
             "Multi-Major": 1,
@@ -37,7 +38,7 @@ class GetPackageStatsTests(TestCase):
 
     def test_outdated_major_package(self):
         packages = [([1, 0, 0], 'test', '2.5', '1.0')]
-        stats = get_package_stats(packages)
+        stats = get_outdated_package_stats(packages)
         self.assertEqual(stats, {
             "Outdated": 1,
             "Multi-Major": 0,
@@ -49,7 +50,7 @@ class GetPackageStatsTests(TestCase):
 
     def test_outdated_minor_package(self):
         packages = [([0, 5, 0], 'test', '2.5', '2.0')]
-        stats = get_package_stats(packages)
+        stats = get_outdated_package_stats(packages)
         self.assertEqual(stats, {
             "Outdated": 1,
             "Multi-Major": 0,
@@ -61,7 +62,7 @@ class GetPackageStatsTests(TestCase):
 
     def test_outdated_patch_package(self):
         packages = [([0, 0, 3], 'test', '2.5.4', '2.5.1')]
-        stats = get_package_stats(packages)
+        stats = get_outdated_package_stats(packages)
         self.assertEqual(stats, {
             "Outdated": 1,
             "Multi-Major": 0,
@@ -73,7 +74,7 @@ class GetPackageStatsTests(TestCase):
 
     def test_unknown_package(self):
         packages = [(None, 'test', 'unknown', '2.5.1')]
-        stats = get_package_stats(packages)
+        stats = get_outdated_package_stats(packages)
         self.assertEqual(stats, {
             "Outdated": 1,
             "Multi-Major": 0,


### PR DESCRIPTION
I left out the "total" metric when porting the scripts over to python. This PR adds support for collecting the total count of packages installed for both `pip` and `yarn`.

Tested locally 
```
➜  dependency-metrics git:(gh/send-total) ✗ metrics pip --stats
Total: 39
Outdated: 11
Multi-Major: 1
Major: 2
Minor: 7
Patch: 1
Unknown: 0
```