### PR TITLE
Support outdated package that is currently on a mixed version (e.g., 1.0.0-alpha)

### DIFF
--- a/dependency_metrics/metrics.py
+++ b/dependency_metrics/metrics.py
@@ -59,7 +59,7 @@ def get_outdated_package_stats(packages):
         "Patch": 0,
         "Unknown": 0,
     }
-    for delta, name, current, latest in packages:
+    for delta, name, _, _ in packages:
         if delta and any(delta):
             major, minor, patch = delta
             if major:

--- a/dependency_metrics/metrics.py
+++ b/dependency_metrics/metrics.py
@@ -60,7 +60,7 @@ def get_outdated_package_stats(packages):
         "Unknown": 0,
     }
     for delta, name, current, latest in packages:
-        if delta:
+        if delta and any(delta):
             major, minor, patch = delta
             if major:
                 assert not minor and not patch, delta

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -25,7 +25,7 @@ class BuildPackagesTableTests(TestCase):
 class GetOutdatedPackageStatsTests(TestCase):
 
     def test_outdated_multi_major_package(self):
-        packages = [([2, 0, 0], 'test', '3.1', '1.0')]
+        packages = [([2, 0, 0], 'test', '1.0', '3.1')]
         stats = get_outdated_package_stats(packages)
         self.assertEqual(stats, {
             "Outdated": 1,
@@ -37,7 +37,7 @@ class GetOutdatedPackageStatsTests(TestCase):
         })
 
     def test_outdated_major_package(self):
-        packages = [([1, 0, 0], 'test', '2.5', '1.0')]
+        packages = [([1, 0, 0], 'test', '1.0', '2.5')]
         stats = get_outdated_package_stats(packages)
         self.assertEqual(stats, {
             "Outdated": 1,
@@ -49,7 +49,7 @@ class GetOutdatedPackageStatsTests(TestCase):
         })
 
     def test_outdated_minor_package(self):
-        packages = [([0, 5, 0], 'test', '2.5', '2.0')]
+        packages = [([0, 5, 0], 'test', '2.0', '2.5')]
         stats = get_outdated_package_stats(packages)
         self.assertEqual(stats, {
             "Outdated": 1,
@@ -61,7 +61,7 @@ class GetOutdatedPackageStatsTests(TestCase):
         })
 
     def test_outdated_patch_package(self):
-        packages = [([0, 0, 3], 'test', '2.5.4', '2.5.1')]
+        packages = [([0, 0, 3], 'test', '2.5.1', '2.5.4')]
         stats = get_outdated_package_stats(packages)
         self.assertEqual(stats, {
             "Outdated": 1,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -83,3 +83,16 @@ class GetOutdatedPackageStatsTests(TestCase):
             "Patch": 0,
             "Unknown": 1,
         })
+
+    def test_outdated_mixed_version(self):
+        # the behind function parses these two versions identically
+        packages = [([0, 0, 0], 'test', '3.0.0', '3.0.0-alpha')]
+        stats = get_outdated_package_stats(packages)
+        self.assertEqual(stats, {
+            "Outdated": 1,
+            "Multi-Major": 0,
+            "Major": 0,
+            "Minor": 0,
+            "Patch": 0,
+            "Unknown": 1,
+        })

--- a/tests/test_parsing_utils.py
+++ b/tests/test_parsing_utils.py
@@ -48,6 +48,10 @@ class BehindTests(TestCase):
         delta = behind("unknown", "1.0.0")
         self.assertEqual(delta, None)
 
+    def test_mixed_version_delta(self):
+        delta = behind("1.0.0", "1.0.0-alpha")
+        self.assertEqual(delta, [0, 0, 0])
+
 
 class ParseVersionTests(TestCase):
 


### PR DESCRIPTION
There is currently a bug when comparing two versions like 3.0.0-alpha and 3.0.0. As you can see in the test output below, if there is a valid delta, which `[0, 0, 0]` is, we will assume one of those three values is a non-zero value.


```
packages = [([0, 0, 0], 'test', '3.0.0', '3.0.0-alpha')]                                                                                                            [470/843]
                                                                                                                                                                             
    def get_outdated_package_stats(packages):                                                                                                                                
        """Displays a count for each version category of out of date dependencies"""                                                                                         
        stats = {                                                                                                                                                            
            "Outdated": 0,                                                                                                                                                   
            "Multi-Major": 0,                                                                                                                                                
            "Major": 0,                                                                                                                                                      
            "Minor": 0,                                                                                                                                                      
            "Patch": 0,                                                                                                                                                      
            "Unknown": 0,                                                                                                                                                    
        }                                                                                                                                                                    
        for delta, name, current, latest in packages:                                                                                                                        
            if delta:                                                                                                                                                        
                major, minor, patch = delta                                                                                                                                  
                if major:                                                                                                                                                    
                    assert not minor and not patch, delta                                                                                                                    
                    if major == 1:                                                                                                                                           
                        key = "Major"                                                                                                                                        
                    else:                                                                                                                                                    
                        key = "Multi-Major"                                                                                                                                  
                elif minor:                                                                                                                                                  
                    assert not major and not patch, delta                                                                                                                    
                    key = "Minor"                                                                                                                                            
                else:                                                                                                                                                        
>                   assert patch and not major and not minor, delta                                                                                                          
E                   AssertionError: [0, 0, 0] 
````

A better long term solution might be to treat the diff between these two versions as `[0, 0, 1]` (a patch difference), rather than an unknown difference, but I wanted to get a simple fix in for this bug.